### PR TITLE
feat: support fcitx switching in terminal mode

### DIFF
--- a/plugin/fcitx.lua
+++ b/plugin/fcitx.lua
@@ -43,5 +43,7 @@ vim.cmd[[
     au InsertLeave * :lua _Fcitx2en()
     au CmdlineEnter [/\?] :lua _Fcitx2NonLatin()
     au CmdlineLeave [/\?] :lua _Fcitx2en()
+    au TermEnter * :lua _Fcitx2NonLatin()
+    au TermLeave * :lua _Fcitx2en()
   augroup END
 ]]


### PR DESCRIPTION
  Summary
  This PR extends the automatic input method switching functionality to Neovim terminal buffers.

  Motivation
  When using terminal mode, users often switch back to Normal mode using <C-\><C-n>. Previously, the plugin only handled Insert and Cmdline modes. This change ensures that the input method is automatically managed when entering or leaving terminal mode, providing a consistent experience
  across all buffer types.

  Changes
  Added the following autocommands to the fcitx augroup in plugin/fcitx.lua:
   - `TermEnter`: Calls _Fcitx2NonLatin() to restore the previous input method state when entering terminal mode.
   - `TermLeave`: Calls _Fcitx2en() to switch to English when leaving terminal mode (e.g., returning to Normal mode).

  Impact
  When you exit terminal mode (e.g., via CTRL-\ CTRL-n), the input method will now automatically switch to English, preventing accidental non-Latin input while navigating. Conversely, it will restore your previous input method state when you jump back into the terminal.
